### PR TITLE
Disable prop-types validation in ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,7 @@ export default [
       ],
       'import/no-unresolved': 'error',
       'react-hooks/rules-of-hooks': 'error',
+      'react/prop-types': 'off',
     },
   },
 ];


### PR DESCRIPTION
# Pull Request 제목:
Eslint PropTypes 검증 비활성화

## 변경 사항 요약
빠른 개발을 위해 불필요한 Eslint PropTypes 검증 비활성화
