### PR TITLE
feat: Add image grid with zoom dialog

### DIFF
--- a/src/constants/note.constants.js
+++ b/src/constants/note.constants.js
@@ -37,7 +37,9 @@ export const mockNotes = [
     title: 'Project Planning Notes',
     content:
       'Need to review the quarterly goals and set up team meetings for next sprint. Key points:\n- Update project timeline\n- Schedule stakeholder review\n- Prepare presentation materials\n- Follow up with design team',
-    images: [],
+    images: [
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756020638/s05mwwhlbyrbqznvpmxg.png',
+    ],
     category: CATEGORIES.TASK,
     completion: {
       dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
@@ -79,7 +81,12 @@ export const mockNotes = [
     title: 'Book Recommendations',
     content:
       'Books to read this month:\n1. "Atomic Habits" by James Clear\n2. "Deep Work" by Cal Newport\n3. "The Pragmatic Programmer"\n4. "Designing Data-Intensive Applications"',
-    images: [],
+    images: [
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756020709/ovy5hqdol5wi6s053q6v.jpg',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756020779/cgi7bqhbmtla1obnfkqt.webp',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756020779/xlacucmtkggs848otds7.jpg',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756020904/nzvp2cbfaxvmm1jao6ms.jpg',
+    ],
     category: CATEGORIES.PERSONAL,
     completion: null,
     createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
@@ -174,5 +181,25 @@ export const mockNotes = [
     },
     createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
     updatedAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+  },
+  {
+    _id: '12',
+    userId: 'user-1',
+    title: 'Image Test',
+    content: 'Image Test',
+    images: [
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756017580/l4q9ydstzy5rdjira7cl.png',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756017580/cgx4a6nhd1ayijwmtnfn.png',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756017580/oqtacaskdgnurmytcpbe.png',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756017580/x4onyhjqeo7tws9k9rdx.png',
+      'https://res.cloudinary.com/ddw9xklog/image/upload/v1756017580/pgjekmva8lwhdgdegimp.png',
+    ],
+    category: CATEGORIES.TASK,
+    completion: {
+      dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      isCompleted: false,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
   },
 ];

--- a/src/pages/CollectionPage/components/NoteCard.jsx
+++ b/src/pages/CollectionPage/components/NoteCard.jsx
@@ -1,6 +1,6 @@
 import { Box, Typography, Chip, IconButton, Checkbox } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { Trash2 } from 'lucide-react';
+import { Image, Trash2 } from 'lucide-react';
 import React from 'react';
 
 import { formatRelativeDate } from '../../../utils/dateUtils';
@@ -70,6 +70,9 @@ const NoteCard = ({ note, isSelected, onSelect, onToggleDone, onDeleteNote }) =>
             >
               {note.title}
             </Typography>
+            {note.images.length > 0 && (
+              <Image size={'1rem'} strokeWidth={1.7} color={theme.palette.border.strong} />
+            )}
           </Box>
 
           <Typography

--- a/src/pages/CollectionPage/components/NoteDetail.jsx
+++ b/src/pages/CollectionPage/components/NoteDetail.jsx
@@ -8,9 +8,21 @@ import {
   MenuItem,
   Checkbox,
   FormControlLabel,
+  Grid,
+  Dialog,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { ArrowLeft, Edit2, Save, X, Calendar, Trash, Clock, AlertCircle } from 'lucide-react';
+import {
+  ArrowLeft,
+  Edit2,
+  Save,
+  X,
+  Calendar,
+  Trash,
+  Clock,
+  AlertCircle,
+  ZoomIn,
+} from 'lucide-react';
 import React, { useState } from 'react';
 
 import { CATEGORIES } from '../../../constants/note.constants';
@@ -36,6 +48,8 @@ const NoteDetail = ({ note, onBack, isMobile, onToggleDone, onDeleteNote }) => {
 
   const category = note?.category || null;
   const hasCompletion = note?.completion !== null;
+
+  const [selectedImage, setSelectedImage] = useState(null);
 
   if (!note) {
     return (
@@ -345,6 +359,125 @@ const NoteDetail = ({ note, onBack, isMobile, onToggleDone, onDeleteNote }) => {
           </Typography>
         )}
       </Box>
+
+      {note.images.length > 0 && (
+        <>
+          <Typography
+            sx={{
+              borderTop: `1px solid ${theme.palette.border.default}`,
+              paddingTop: 3,
+              paddingInline: 3,
+              color: theme.palette.text.secondary,
+              fontSize: '0.75rem',
+              fontWeight: 600,
+            }}
+          >
+            ATTACHMENTS ({note.images.length})
+          </Typography>
+
+          <Grid
+            container
+            sx={{
+              display: 'flex',
+              justifyContent: 'start',
+              alignItems: 'center',
+              padding: 2,
+            }}
+          >
+            {note.images.map((image, idx) => (
+              <Grid
+                key={idx}
+                size={{ xs: 4, sm: 2.4, md: 4, lg: 2.4 }}
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  padding: 1,
+                }}
+              >
+                <Box
+                  onClick={() => setSelectedImage(image)}
+                  sx={{
+                    position: 'relative',
+                    width: '100px',
+                    height: '100px',
+                    borderRadius: '8px',
+                    overflow: 'hidden',
+                    boxShadow: '1px 1px 3px #00000037',
+                    '&:hover img': { transform: 'scale(1.05)' },
+                    '&:hover .zoom-icon': { opacity: 1 },
+                  }}
+                >
+                  <img
+                    src={image}
+                    alt={`image ${idx}`}
+                    style={{
+                      objectFit: 'cover',
+                      width: '100%',
+                      height: '100%',
+                      cursor: 'pointer',
+                      transition: 'transform 0.3s ease',
+                    }}
+                  />
+
+                  <Box
+                    className="zoom-icon"
+                    sx={{
+                      position: 'absolute',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      width: '100%',
+                      height: '100%',
+                      top: '50%',
+                      left: '50%',
+                      transform: 'translate(-50%, -50%)',
+                      opacity: 0,
+                      transition: 'opacity 0.3s ease',
+                      color: '#fff',
+                      backgroundColor: 'rgba(0,0,0,0.4)',
+                      padding: '4px',
+                    }}
+                  >
+                    <ZoomIn size={'1.2rem'} />
+                  </Box>
+                </Box>
+              </Grid>
+            ))}
+          </Grid>
+        </>
+      )}
+      <Dialog open={!!selectedImage} onClose={() => setSelectedImage(null)} maxWidth="lg">
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', p: 2 }}>
+          <Box>
+            <IconButton
+              onClick={() => setSelectedImage(null)}
+              sx={{
+                position: 'absolute',
+                top: 16,
+                right: 16,
+                color: 'white',
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                },
+              }}
+            >
+              <X size={20} strokeWidth={3} />
+            </IconButton>
+          </Box>
+          {selectedImage && (
+            <img
+              src={selectedImage}
+              alt="img"
+              style={{
+                maxWidth: '100%',
+                maxHeight: '80vh',
+                objectFit: 'contain',
+              }}
+            />
+          )}
+        </Box>
+      </Dialog>
     </Box>
   );
 };

--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -134,6 +134,7 @@ const LandingPage = () => {
                 src={url}
                 alt={`img-${index}`}
                 sx={{
+                  objectFit: 'cover',
                   width: 80,
                   height: 80,
                   borderRadius: '0.5rem',


### PR DESCRIPTION
# Note DeTail에 Image grid 추가

## 변경 사항 요약
- 이미지가 있는 노트의 경우 title 옆에 이미지 아이콘 표시
- Note Detail 컴포넌트에 첨부 이미지를 Grid로 표시
- 클릭 / 터치 시 dialog 모달로 이미지 크게 보기
- (Landing) 이미지 썸네일 비율 통일을 위한 objectFit cover 적용

<img width="180" height="98" alt="image" src="https://github.com/user-attachments/assets/1afb6ce1-a6e2-49d3-9a74-fe0f78ad5d83" />


<img width="136" height="182" alt="image" src="https://github.com/user-attachments/assets/dd9df89a-93d0-4c19-98ed-fa28b3098d5a" />
<img width="82" height="179" alt="image" src="https://github.com/user-attachments/assets/ecf20ece-fdc9-42c6-af07-746b3289fa3e" />  
<img width="82" height="179" alt="image" src="https://github.com/user-attachments/assets/daad4932-3a05-4f00-9787-14f6b2b9e4da" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 노트 상세에 첨부 이미지 섹션 추가: 썸네일 그리드, 클릭 시 전체 화면 라이트박스(확대 오버레이, 닫기 지원).

- UI
  - 노트 카드에서 이미지가 있는 경우 제목 옆에 이미지 아이콘 표시.
  - 랜딩 페이지 썸네일이 80×80 영역을 꽉 채우도록 개선(object-fit: cover).

- 작업(Chores)
  - 목업 노트에 이미지 추가 및 이미지가 많은 샘플 노트 신규 포함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->