### PR TITLE
refactor: Relocate navigate click handler for  clarity

### DIFF
--- a/src/layout/components/TopNavigation.jsx
+++ b/src/layout/components/TopNavigation.jsx
@@ -44,7 +44,6 @@ const TopNavigation = () => {
     >
       <Box>
         <Box
-          onClick={() => navigate('/')}
           sx={{
             display: 'flex',
             justifyContent: 'space-between',
@@ -54,6 +53,7 @@ const TopNavigation = () => {
           }}
         >
           <Box
+            onClick={() => navigate('/')}
             sx={{
               width: '120px',
               height: '31px',


### PR DESCRIPTION
# 모바일 drawer navigate 핸들러 범위 수정

## 변경 사항 요약
- X 버튼을 눌러도 랜딩페이지로 이동되지 않도록 범위 수정. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 헤더의 빈 영역을 클릭해도 홈으로 이동하지 않도록 조정하고, 로고를 클릭할 때만 홈으로 이동하도록 변경했습니다. 오탭으로 인한 예기치 않은 페이지 이동을 방지하고, 내비게이션 동작의 일관성과 사용자 경험을 개선했습니다. 다른 내비게이션 기능에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->