### PR TITLE
feat: Add theme toggle button

### DIFF
--- a/src/layout/components/ProfileMenu.jsx
+++ b/src/layout/components/ProfileMenu.jsx
@@ -1,4 +1,13 @@
-import { Box, IconButton, ListItemIcon, Menu, MenuItem, Tooltip, Divider } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  ListItemIcon,
+  Menu,
+  MenuItem,
+  Tooltip,
+  Divider,
+  useTheme,
+} from '@mui/material';
 import { LogOut, User } from 'lucide-react';
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -6,6 +15,7 @@ import { useDispatch } from 'react-redux';
 import { logout } from '../../features/auth/authSlice';
 
 export default function ProfileMenu() {
+  const theme = useTheme();
   const dispatch = useDispatch();
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -38,7 +48,7 @@ export default function ProfileMenu() {
             aria-haspopup="true"
             aria-expanded={open ? 'true' : undefined}
           >
-            <User color="#737373" size={20} strokeWidth={1.5} />
+            <User color={theme.palette.text.primary} size={20} strokeWidth={1.5} />
           </IconButton>
         </Tooltip>
       </Box>

--- a/src/layout/components/TopNavigation.jsx
+++ b/src/layout/components/TopNavigation.jsx
@@ -1,6 +1,6 @@
 import { Button, Drawer, Typography } from '@mui/material';
 import { Box, useTheme } from '@mui/system';
-import { FolderOpen, Calendar, User, Moon, AlignJustify, X, LogOut } from 'lucide-react';
+import { FolderOpen, Calendar, User, AlignJustify, X, LogOut } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import ProfileMenu from './ProfileMenu.jsx';
 import Logo from '../../assets/logo.png';
 import { logout } from '../../features/auth/authSlice.js';
+import ThemeToggle from '../../theme/ThemeToggle.jsx';
 
 const TopNavigation = () => {
   const theme = useTheme();
@@ -119,23 +120,7 @@ const TopNavigation = () => {
           borderTop: `1px solid  ${theme.palette.border.default}`,
         }}
       >
-        <Button
-          sx={{
-            display: 'flex',
-            justifyContent: 'start',
-            alignContent: 'center',
-            gap: '0.875rem',
-            color: theme.palette.text.primary,
-            padding: '8px 12px',
-            marginBottom: '0.5rem',
-            fontSize: '14px',
-            height: '3rem',
-            width: '100%',
-          }}
-        >
-          <Moon width={16} />
-          <Typography fontSize={'14px'}>Dark Mode</Typography>
-        </Button>
+        <ThemeToggle variant="drawer" />
         <Button
           onClick={() => navigate(user ? dispatch(logout()) : '/login')}
           sx={{
@@ -222,17 +207,7 @@ const TopNavigation = () => {
           zIndex: 10,
         }}
       >
-        <Button
-          disableRipple
-          sx={{
-            minWidth: '48px',
-            height: '48px',
-            padding: 0,
-            borderRadius: '30px',
-          }}
-        >
-          <Moon color="#737373" size={20} strokeWidth={1.5} />
-        </Button>
+        <ThemeToggle variant="default" />
         {user ? (
           <ProfileMenu />
         ) : (
@@ -246,7 +221,7 @@ const TopNavigation = () => {
               borderRadius: '30px',
             }}
           >
-            <User color="#737373" size={20} strokeWidth={1.5} />
+            <User color={theme.palette.text.primary} size={20} strokeWidth={1.5} />
           </Button>
         )}
       </Box>

--- a/src/theme/ThemeToggle.jsx
+++ b/src/theme/ThemeToggle.jsx
@@ -1,0 +1,52 @@
+import { Button, Typography, useTheme } from '@mui/material';
+import { Moon, Sun } from 'lucide-react';
+import React from 'react';
+
+import { useColorMode } from './themeProvider';
+
+export default function ThemeToggle({ variant = 'default' }) {
+  const theme = useTheme();
+  const { mode, toggle } = useColorMode();
+
+  return variant === 'default' ? (
+    <Button
+      disableRipple
+      sx={{
+        minWidth: '48px',
+        height: '48px',
+        padding: 0,
+        borderRadius: '30px',
+      }}
+      onClick={toggle}
+    >
+      {mode === 'light' ? (
+        <Moon color={theme.palette.text.primary} size={20} strokeWidth={1.5} />
+      ) : (
+        <Sun color={theme.palette.text.primary} size={20} strokeWidth={1.5} />
+      )}
+    </Button>
+  ) : (
+    <Button
+      sx={{
+        display: 'flex',
+        justifyContent: 'start',
+        alignContent: 'center',
+        gap: '0.875rem',
+        color: theme.palette.text.primary,
+        padding: '8px 12px',
+        marginBottom: '0.5rem',
+        fontSize: '14px',
+        height: '3rem',
+        width: '100%',
+      }}
+      onClick={toggle}
+    >
+      {mode === 'light' ? (
+        <Moon color={theme.palette.text.primary} size={16} strokeWidth={1.5} />
+      ) : (
+        <Sun color={theme.palette.text.primary} size={16} strokeWidth={1.5} />
+      )}
+      <Typography fontSize={'14px'}>{mode === 'light' ? 'Dark Mode' : 'Light Mode'}</Typography>
+    </Button>
+  );
+}


### PR DESCRIPTION
# Pull Request 제목: 
feat: Add theme toggle button

## 변경 사항 요약
- 테마 토글 버튼 추가

## 상세 설명
- 테마 토글 버튼 추가 (Nav, SideBar)

## 기타 참고 사항
- 몇몇 UI darkmode 색상 적용 안돼있어서 수정이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  - 테마 전환을 위한 새 토글 추가로 다크/라이트 모드를 즉시 전환 가능. 상단 내비게이션과 드로어 모두에서 사용되며, 상황에 맞는 두 가지 표시 형태를 지원.

* 스타일
  - 사용자/전환 아이콘이 현재 테마의 텍스트 색상에 자동 맞춤되어 가독성 향상.
  - 기존 달 아이콘 기반 다크 모드 버튼을 토글로 교체해 인터페이스 일관성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->