### PR TITLE
fix: Fix navigate error when register fulfilled

### DIFF
--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -89,10 +89,9 @@ const authSlice = createSlice({
         state.isLoading = true;
         state.error = null;
       })
-      .addCase(register.fulfilled, (state, action) => {
+      .addCase(register.fulfilled, (state) => {
         state.isLoading = false;
         state.error = null;
-        state.user = action.payload.user;
       })
       .addCase(register.rejected, (state, action) => {
         state.isLoading = false;


### PR DESCRIPTION
# Pull Request 제목:
fix: Fix navigate error when register fulfilled
## 변경 사항 요약
- 회원가입 성공시 네비게이트 오류 수정

## 상세 설명
- 원인: user slice 정보 저장으로 인한 public route 오작동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 회원가입 완료 시 로딩 상태가 확실히 종료되고 오류 메시지가 초기화되어, 가입 흐름의 안정성과 피드백이 개선되었습니다.
  * 가입 직후 사용자 정보가 자동 반영되던 동작을 제거해 일시적 불일치나 잘못된 표시가 발생할 가능성을 줄였습니다.
  * 이제 화면의 사용자 정보 갱신은 명시적인 재로드 또는 로그인 절차를 통해 이뤄집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->