### PR TITLE
feat: Add a simple modal for user information

### DIFF
--- a/src/layout/components/ProfileMenu.jsx
+++ b/src/layout/components/ProfileMenu.jsx
@@ -14,7 +14,7 @@ import { useDispatch } from 'react-redux';
 
 import { logout } from '../../features/auth/authSlice';
 
-export default function ProfileMenu() {
+export default function ProfileMenu({ setOpenUserInfo }) {
   const theme = useTheme();
   const dispatch = useDispatch();
   const [anchorEl, setAnchorEl] = useState(null);
@@ -24,6 +24,11 @@ export default function ProfileMenu() {
   };
   const handleClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleOpenUserInfo = () => {
+    setOpenUserInfo(true);
+    handleClose();
   };
 
   const handleLogout = () => {
@@ -44,9 +49,6 @@ export default function ProfileMenu() {
               padding: 0,
               borderRadius: '30px',
             }}
-            aria-controls={open ? 'account-menu' : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
           >
             <User color={theme.palette.text.primary} size={20} strokeWidth={1.5} />
           </IconButton>
@@ -89,7 +91,7 @@ export default function ProfileMenu() {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
-        <MenuItem onClick={handleClose} sx={{ minHeight: 32, fontSize: '0.85rem' }}>
+        <MenuItem onClick={handleOpenUserInfo} sx={{ minHeight: 32, fontSize: '0.85rem' }}>
           <ListItemIcon>
             <User size={16} />
           </ListItemIcon>

--- a/src/layout/components/TopNavigation.jsx
+++ b/src/layout/components/TopNavigation.jsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import ProfileMenu from './ProfileMenu.jsx';
+import UserInfoModal from './UserInfoModal.jsx';
 import Logo from '../../assets/logo.png';
 import { logout } from '../../features/auth/authSlice.js';
 import ThemeToggle from '../../theme/ThemeToggle.jsx';
@@ -17,6 +18,7 @@ const TopNavigation = () => {
   const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
+  const [openUserInfo, setOpenUserInfo] = useState(false);
   const [hasScrolled, setHasScrolled] = useState(false);
   const { user } = useSelector((state) => state.auth);
 
@@ -209,7 +211,10 @@ const TopNavigation = () => {
       >
         <ThemeToggle variant="default" />
         {user ? (
-          <ProfileMenu />
+          <>
+            <ProfileMenu setOpenUserInfo={setOpenUserInfo} />
+            <UserInfoModal open={openUserInfo} onClose={() => setOpenUserInfo(false)} user={user} />
+          </>
         ) : (
           <Button
             onClick={() => navigate('/login')}

--- a/src/layout/components/UserInfoModal.jsx
+++ b/src/layout/components/UserInfoModal.jsx
@@ -1,0 +1,53 @@
+import CloseIcon from '@mui/icons-material/Close';
+import {
+  Avatar,
+  Box,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  Stack,
+  Typography,
+  Button,
+} from '@mui/material';
+import React from 'react';
+
+export default function UserInfoModal({ open, onClose, user }) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xs"
+      disableEnforceFocus
+      disableAutoFocus
+    >
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 2 }}>
+        <Typography variant="h6">사용자 정보</Typography>
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+
+      <DialogContent dividers>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar sx={{ width: 48, height: 48 }} />
+          <Stack>
+            <Typography variant="subtitle1" fontWeight={600} noWrap>
+              {user.name}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" noWrap title={user.email}>
+              {user.email}
+            </Typography>
+          </Stack>
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} variant="contained" size="small" sx={{ margin: '0.5rem' }}>
+          닫기
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Pull Request 제목: (간결하게 주요 변경사항 작성)
feat: Add a simple modal for user information

## 변경 사항 요약
- 유저 정보 확인 모달창 추가

## 상세 설명
- 헤더 -> 프로필 -> 유저 정보 표시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 사용자 정보 모달을 추가했습니다. 아바타, 이름, 이메일을 한눈에 확인하고 닫기 버튼으로 간편히 종료할 수 있습니다. 모바일 환경에서도 폭이 최적화된 대화상자로 표시됩니다.
- 개선
  - 프로필 메뉴에서 ‘사용자 정보’ 선택 시 모달이 즉시 열리고 메뉴는 자동으로 닫힙니다. 로그인 상태의 상단 내비게이션에서 모달을 바로 사용할 수 있어 흐름이 더 자연스러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->