### PR TITLE
fix: add initialDate to calendar, adjust color thresholds and correct total label

### DIFF
--- a/src/pages/CalendarPage/components/MainCalendar.jsx
+++ b/src/pages/CalendarPage/components/MainCalendar.jsx
@@ -270,11 +270,12 @@ const MainCalendar = ({ statics, currentDate, onDateChange }) => {
       <Box sx={calendarStyles}>
         <FullCalendar
           plugins={[dayGridPlugin]}
+          initialDate={currentDate}
           initialView="dayGridMonth"
           headerToolbar={{
-            left: 'prev,next',
+            left: 'today',
             center: 'title',
-            right: 'today',
+            right: 'prev,next',
           }}
           events={SimpleEvents}
           height="100%"

--- a/src/pages/CalendarPage/components/TaskCountHeatmap.jsx
+++ b/src/pages/CalendarPage/components/TaskCountHeatmap.jsx
@@ -69,9 +69,9 @@ const TaskCountHeatmap = ({ statics, currentDate }) => {
 
   const getColorIntensity = (count) => {
     if (count === 0) return COLORS.empty;
-    if (count <= 3) return COLORS.low;
-    if (count <= 6) return COLORS.medium;
-    if (count <= 9) return COLORS.high;
+    if (count <= 2) return COLORS.low;
+    if (count <= 4) return COLORS.medium;
+    if (count <= 6) return COLORS.high;
     return COLORS.veryHigh;
   };
 
@@ -179,7 +179,7 @@ const TaskCountHeatmap = ({ statics, currentDate }) => {
 
       <Box sx={{ mt: 1, textAlign: 'center' }}>
         <Typography sx={{ fontSize: '0.75rem', color: theme.palette.text.secondary }}>
-          total: <strong>{status.total}</strong>
+          total: <strong>{statics.total}</strong>
         </Typography>
       </Box>
     </Paper>


### PR DESCRIPTION
# 캘린더 페이지 달력 이동 오류 수정

## 변경 사항 요약
- initialDate 속성
- 히트맵 색상 값 조정
- 오타 수정
- 달력 버튼 위치 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 캘린더가 지정된 현재 날짜로 초기화되며, 헤더가 오늘 버튼(왼쪽)과 이전/다음(오른쪽)으로 재배치되어 탐색이 더 직관적입니다.
  - 작업 수 히트맵의 색상 구간을 0, 1–2, 3–4, 5–6, 7+로 재구성하여 높은 밀도 영역을 더 명확히 구분합니다.

- Bug Fixes
  - 히트맵 총합 표시가 잘못된 데이터 소스를 참조하던 문제를 수정해 정확한 값이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->