### PR TITLE
feature: Persist theme mode in localStorage

### DIFF
--- a/src/theme/themeProvider.jsx
+++ b/src/theme/themeProvider.jsx
@@ -8,13 +8,21 @@ const ColorModeContext = createContext({ mode: 'light', toggle: () => {} });
 export const useColorMode = () => useContext(ColorModeContext);
 
 export default function ThemeRegistry({ children }) {
-  const [mode, setMode] = useState('light');
+  const [mode, setMode] = useState(() => {
+    const savedMode = localStorage.getItem('themeMode');
+    return savedMode === 'dark' ? 'dark' : 'light';
+  });
   const theme = useMemo(() => makeTheme(mode), [mode]);
 
-  const api = useMemo(
-    () => ({ mode, toggle: () => setMode((m) => (m === 'light' ? 'dark' : 'light')) }),
-    [mode],
-  );
+  const toggleMode = () => {
+    setMode((prev) => {
+      const next = prev === 'light' ? 'dark' : 'light';
+      localStorage.setItem('themeMode', next);
+      return next;
+    });
+  };
+
+  const api = useMemo(() => ({ mode, toggle: toggleMode }), [mode]);
 
   return (
     <ColorModeContext.Provider value={api}>


### PR DESCRIPTION
# theme 모드 정보 LocalStorage에 저장

## 변경 사항 요약
- theme 모드 정보 LocalStorage에 저장

## 상세 설명
- 새로고침 해도 theme 모드가 유지되도록 LocalStorage에 저장.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 테마 모드가 브라우저 로컬 저장소에 저장되어, 브라우저/탭을 닫았다가 다시 열어도 마지막 사용 모드가 자동 적용됩니다.
  * 라이트/다크 전환 시 설정이 즉시 저장되어 페이지 이동이나 새로고침 후에도 일관된 시각 경험을 제공합니다.
  * 최초 방문 시 기본값은 라이트 모드이며, 이전에 다크 모드를 선택한 경우 자동으로 다크 모드가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->