### PR TITLE
refactor: remove automatic note selection in getNotes and add conditi…

### DIFF
--- a/src/features/notes/noteSlice.js
+++ b/src/features/notes/noteSlice.js
@@ -23,11 +23,6 @@ export const getNotes = createAsyncThunk(
       if (isCompleted !== undefined) params.isCompleted = isCompleted;
 
       const { data } = await api.get('/notes', { params });
-
-      if (data.notes.length > 0) {
-        dispatch(getNote(data.notes[0]._id));
-      }
-
       return data.notes;
     } catch (error) {
       const errorMessage = extractErrorMessage(error);

--- a/src/pages/CollectionPage/CollectionPage.jsx
+++ b/src/pages/CollectionPage/CollectionPage.jsx
@@ -27,6 +27,12 @@ const CollectionPage = () => {
     dispatch(getNotes(params));
   }, [dispatch, currentCategory]);
 
+  useEffect(() => {
+    if (!isMobile && !selectedNote && notes.length > 0) {
+      dispatch(getNote(notes[0]._id));
+    }
+  }, [isMobile, selectedNote, notes, dispatch]);
+
   const handleNoteSelect = (note) => {
     dispatch(getNote(note._id));
   };


### PR DESCRIPTION
# Pull Request 제목
Collection page 자동 선택 로직 수정

## 변경 사항 요약
desktop view에서만 note의 0번째 항목을 자동 선택하고,
모바일 view에서는 선택하지 않도록 로직 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 비모바일 환경에서 선택된 노트가 없고 노트가 존재할 경우, 첫 번째 노트를 자동으로 열어 바로 내용을 확인할 수 있습니다. 모바일에는 영향이 없습니다.

- 리팩터
  - 초기 노트 로딩 동작을 화면 단에서 관리하도록 정리하여, 환경별(모바일/비모바일) 동작을 더 일관되게 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->