### PR TITLE
fix: Prevent 401 interceptor redirect loop on login/register pages (f…

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -21,7 +21,11 @@ api.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       sessionStorage.removeItem('token');
-      window.location.href = '/login';
+      // 로그인/ 레지스터 페이지에 있지 않을 때만 리다이렉트
+      const currentPath = window.location.pathname;
+      if (!currentPath.includes('/login') && !currentPath.includes('/register')) {
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   },


### PR DESCRIPTION
…ix clearing error messages on auth pages too quickly)

# fix: Prevent 401 interceptor redirect loop on login/register pages

## 변경 사항 요약
- 로그인/회원가입 페이지에서 401 에러 발생 시 무한 리다이렉트 문제 해결
- 잘못된 로그인 정보 입력 시 에러 메시지가 즉시 사라지는 문제 수정

## 상세 설명
API 인터셉터 개선 (`api.js`)
  - 로그인/회원가입 페이지에서는 401 에러 시 리다이렉트하지 않도록 수정
  - 이미 인증 페이지에 있을 때 페이지 새로고침으로 인한 에러 메시지 소실 방지
  - 다른 페이지에서는 기존대로 토큰 만료시 로그인 페이지로 리다이렉트

## 관련 이슈



## 기타 참고 사항
- 로그인/레지스터 페이지의 에레가 즉시 사라지는 문제 해결
